### PR TITLE
"Native" support for validation error icons

### DIFF
--- a/module/app/views/b3/horizontal/b3FieldConstructorHorizontal.scala.html
+++ b/module/app/views/b3/horizontal/b3FieldConstructorHorizontal.scala.html
@@ -2,11 +2,15 @@
 @import play.api.i18n._
 @import helper._
 @errorsAndInfos = @{ elements.errors(elements.lang) ++ elements.infos(elements.lang) }
+@showErrorIcon = @{ elements.args.exists(_ == ('_showErrorIcon, true)) }
 
-<div class="form-group @elements.args.get('_class) @if(elements.hasErrors) {has-error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
+<div class="form-group @elements.args.get('_class)@if(elements.hasErrors) { has-error@if(showErrorIcon) { has-feedback}}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
 	<label class="control-label @colLabel" for="@elements.id">@elements.label(elements.lang)</label>
 	<div class="@colInput">
 		@elements.input
+		@if(elements.hasErrors && showErrorIcon) {
+			<span class="glyphicon glyphicon-remove form-control-feedback"></span>
+		}
 		@errorsAndInfos.map { errorOrInfo =>
 			<span class="help-block">@errorOrInfo</span>
 		}

--- a/module/app/views/b3/inline/b3FieldConstructorInline.scala.html
+++ b/module/app/views/b3/inline/b3FieldConstructorInline.scala.html
@@ -2,10 +2,14 @@
 @import play.api.i18n._
 @import helper._
 @errorsAndInfos = @{ elements.errors(elements.lang) ++ elements.infos(elements.lang) }
+@showErrorIcon = @{ elements.args.exists(_ == ('_showErrorIcon, true)) }
 
-<div class="form-group @elements.args.get('_class) @if(elements.hasErrors) {has-error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
+<div class="form-group @elements.args.get('_class)@if(elements.hasErrors) { has-error@if(showErrorIcon) { has-feedback}}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
 	<label class="control-label @if(!b3.ArgsMap.isTrue(elements.args, '_showLabel)){sr-only}" for="@elements.id">@elements.label(elements.lang)</label>
 	@elements.input
+	@if(elements.hasErrors && showErrorIcon) {
+		<span class="glyphicon glyphicon-remove form-control-feedback"></span>
+	}
 	@errorsAndInfos.map { errorOrInfo =>
 		<span class="help-block">@errorOrInfo</span>
 	}

--- a/module/app/views/b3/vertical/b3FieldConstructorVertical.scala.html
+++ b/module/app/views/b3/vertical/b3FieldConstructorVertical.scala.html
@@ -2,12 +2,16 @@
 @import play.api.i18n._
 @import helper._
 @errorsAndInfos = @{ elements.errors(elements.lang) ++ elements.infos(elements.lang) }
+@showErrorIcon = @{ elements.args.exists(_ == ('_showErrorIcon, true)) }
 
-<div class="form-group @elements.args.get('_class) @if(elements.hasErrors) {has-error}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
+<div class="form-group @elements.args.get('_class)@if(elements.hasErrors) { has-error@if(showErrorIcon) { has-feedback}}" id="@elements.args.get('_id).getOrElse(elements.id + "_field")">
 	@if(!elements.args.exists(_ == ('_label, None))) {
 		<label class="control-label" for="@elements.id">@elements.label(elements.lang)</label>
 	}
 	@elements.input
+	@if(elements.hasErrors && showErrorIcon) {
+		<span class="glyphicon glyphicon-remove form-control-feedback"></span>
+	}
 	@errorsAndInfos.map { errorOrInfo =>
 		<span class="help-block">@errorOrInfo</span>
 	}

--- a/sample/app/views/docs.scala.html
+++ b/sample/app/views/docs.scala.html
@@ -222,6 +222,7 @@
 					<li><code>_showConstraints</code>: indicates if the constraints are shown.</li>
 					<li><code>_help</code>: a help text below the input.</li>
 					<li><code>_showLabel</code>: a boolean indicating if the label must be shown for a helper within an <strong>Inline Field Constructors</strong>.</li>
+					<li><code>_showErrorIcon</code>: indicates if an error icon is shown in case validation fails.</li>
 				</ul>
 			</p>
 	


### PR DESCRIPTION
You can now set `'_showErrorIcon -> true` which will show an error-like icon in case validation failed.
